### PR TITLE
feat(web-renderer): custom renderTarget with embedded dialog mode

### DIFF
--- a/examples/react-render-target/README.md
+++ b/examples/react-render-target/README.md
@@ -1,0 +1,21 @@
+# Proton Web SDK — `renderTarget` example (React)
+
+A minimal React app that mounts the Proton Web SDK dialog inside a specific
+DOM element via the new `renderTarget` option, instead of the default
+`document.body`.
+
+## Run
+
+```bash
+pnpm install
+pnpm --filter example-react-render-target dev
+```
+
+## What it demonstrates
+
+- `uiOptions.renderTarget` passed to `ProtonWebSDK()` — the login modal is
+  appended inside the referenced element.
+- `renderer.setRenderTarget(el)` called before `session.transact(...)` — the
+  sign-request modal re-parents into the same container.
+
+The target can be either an `HTMLElement` or a CSS selector string.

--- a/examples/react-render-target/index.html
+++ b/examples/react-render-target/index.html
@@ -1,0 +1,289 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Proton Web SDK - renderTarget example</title>
+    <style>
+      :root {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        color: #1a1a2e;
+        background: radial-gradient(circle at 30% 20%, #eef1ff 0%, #f5f6fb 60%);
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+      }
+      .page {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 64px 24px;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+      }
+      h1 {
+        margin: 0;
+        font-size: 26px;
+      }
+      p {
+        margin: 0;
+        color: #4a4a68;
+        line-height: 1.5;
+      }
+      code {
+        padding: 1px 6px;
+        background: #eef0fa;
+        border-radius: 4px;
+        font-size: 0.9em;
+      }
+      button {
+        align-self: flex-start;
+        padding: 12px 20px;
+        font-size: 14px;
+        font-weight: 600;
+        color: white;
+        background: #7543e3;
+        border: none;
+        border-radius: 10px;
+        cursor: pointer;
+        transition: transform 0.08s ease, box-shadow 0.15s ease, background 0.15s ease;
+        box-shadow: 0 6px 18px -8px rgba(117, 67, 227, 0.6);
+      }
+      button:hover:not(:disabled) {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 22px -8px rgba(117, 67, 227, 0.7);
+      }
+      button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+      button.secondary {
+        background: transparent;
+        color: #7543e3;
+        box-shadow: inset 0 0 0 1px #d7cdf8;
+      }
+      .actions {
+        display: flex;
+        gap: 12px;
+      }
+      .status {
+        padding: 12px 16px;
+        background: white;
+        border: 1px solid #e3e3ef;
+        border-radius: 10px;
+        font-family: ui-monospace, SFMono-Regular, monospace;
+        font-size: 13px;
+      }
+      .status.muted {
+        background: rgba(255, 255, 255, 0.6);
+        border-color: rgba(255, 255, 255, 0.9);
+        color: #2a2a45;
+      }
+
+      .backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(16, 18, 37, 0.55);
+        backdrop-filter: blur(4px);
+        display: grid;
+        place-items: center;
+        padding: 24px;
+        z-index: 100;
+        animation: fade 0.18s ease-out;
+      }
+      .modal {
+        width: min(880px, 100%);
+        min-height: 520px;
+        display: grid;
+        grid-template-columns: 1fr 340px;
+        background: #020305;
+        border-radius: 18px;
+        overflow: hidden;
+        box-shadow: 0 30px 80px -20px rgba(20, 18, 55, 0.45);
+        animation: pop 0.22s cubic-bezier(0.2, 0.9, 0.3, 1.2);
+      }
+      .message {
+        padding: 32px;
+        background: linear-gradient(160deg, #7543e3 0%, #4b23b8 100%);
+        color: white;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        gap: 24px;
+      }
+      .message-body {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .message h2 {
+        margin: 0;
+        font-size: 24px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+      }
+      .message > .message-body > p {
+        color: rgba(255, 255, 255, 0.85);
+        line-height: 1.55;
+        margin: 0;
+      }
+      .message .status.muted {
+        background: rgba(255, 255, 255, 0.12);
+        border-color: rgba(255, 255, 255, 0.2);
+        color: rgba(255, 255, 255, 0.95);
+      }
+      .message button {
+        align-self: flex-start;
+        background: white;
+        color: #4b23b8;
+        box-shadow: none;
+      }
+      .message button:hover:not(:disabled) {
+        background: #f1ecff;
+      }
+
+      .tasks {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .task {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 14px 16px;
+        background: rgba(255, 255, 255, 0.08);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 12px;
+        transition: background 0.2s ease, border-color 0.2s ease;
+      }
+      .task.active {
+        background: rgba(255, 255, 255, 0.18);
+        border-color: rgba(255, 255, 255, 0.35);
+      }
+      .task.done {
+        background: rgba(34, 197, 94, 0.15);
+        border-color: rgba(34, 197, 94, 0.4);
+      }
+      .task-bullet {
+        flex-shrink: 0;
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.18);
+        color: white;
+        font-size: 12px;
+        font-weight: 700;
+        display: grid;
+        place-items: center;
+      }
+      .task.done .task-bullet {
+        background: #22c55e;
+      }
+      .task-body {
+        flex: 1;
+        min-width: 0;
+        line-height: 1.4;
+      }
+      .task-label {
+        font-weight: 600;
+        font-size: 14px;
+      }
+      .task-sub {
+        margin-top: 2px;
+        font-size: 12px;
+        color: rgba(255, 255, 255, 0.8);
+        font-family: ui-monospace, SFMono-Regular, monospace;
+        word-break: break-all;
+      }
+
+      .render-target {
+        position: relative;
+        background: #fafaff;
+      }
+
+      .success {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        padding: 32px;
+        text-align: center;
+        background: #020305;
+        color: #e7e9f5;
+        animation: pop 0.24s cubic-bezier(0.2, 0.9, 0.3, 1.2);
+      }
+      .success-ring {
+        width: 72px;
+        height: 72px;
+        border-radius: 50%;
+        display: grid;
+        place-items: center;
+        color: white;
+        background: linear-gradient(160deg, #22c55e 0%, #15803d 100%);
+        box-shadow: 0 12px 28px -10px rgba(34, 197, 94, 0.6);
+        margin-bottom: 8px;
+      }
+      .success h3 {
+        margin: 0;
+        font-size: 20px;
+        color: #f6f7fb;
+      }
+      .success .account {
+        margin: 0;
+        padding: 6px 12px;
+        background: rgba(117, 67, 227, 0.18);
+        color: #c5b4ff;
+        border-radius: 999px;
+        font-family: ui-monospace, SFMono-Regular, monospace;
+        font-size: 13px;
+      }
+      .success-hint {
+        margin: 8px 0 0;
+        max-width: 260px;
+        color: #9ca0b8;
+        line-height: 1.5;
+        font-size: 14px;
+      }
+      .success button.burn {
+        margin-top: 24px;
+        align-self: center;
+        background: linear-gradient(160deg, #ff6b6b 0%, #c83535 100%);
+        box-shadow: 0 10px 22px -10px rgba(200, 53, 53, 0.6);
+      }
+      .success button.burn:hover:not(:disabled) {
+        background: linear-gradient(160deg, #ff7e7e 0%, #d94141 100%);
+      }
+
+      @keyframes fade {
+        from { opacity: 0; }
+        to { opacity: 1; }
+      }
+      @keyframes pop {
+        from { opacity: 0; transform: translateY(8px) scale(0.98); }
+        to { opacity: 1; transform: translateY(0) scale(1); }
+      }
+
+      @media (max-width: 640px) {
+        .modal {
+          grid-template-columns: 1fr;
+          min-height: 0;
+        }
+        .render-target {
+          min-height: 460px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-render-target/package.json
+++ b/examples/react-render-target/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "example-react-render-target",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@proton/web-sdk": "workspace:^",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
+    "@vitejs/plugin-react": "^4.4.1",
+    "typescript": "~5.8.3",
+    "vite": "^6.3.5"
+  }
+}

--- a/examples/react-render-target/src/App.tsx
+++ b/examples/react-render-target/src/App.tsx
@@ -1,0 +1,269 @@
+import {useRef, useState} from "react";
+import ProtonWebSDK from "@proton/web-sdk";
+import type {Link, LinkSession, ProtonWebLink} from "@proton/web-sdk";
+
+const REQUEST_ACCOUNT = "taskly";
+const BURN_ACCOUNT = "eosio.null";
+const CHAIN_ID =
+  "71ee83bcf52142d61019d95f9cc5427ba6a0d7ff8accd9e2088ae2abeaf3d3dd";
+const ENDPOINTS = ["https://testnet.rockerone.io"];
+
+type Renderer = NonNullable<
+  Awaited<ReturnType<typeof ProtonWebSDK>>["renderer"]
+>;
+
+type Mode = "connect" | "sign" | "done";
+
+const nextFrame = () =>
+  new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+
+export const App = () => {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+  const linkRef = useRef<ProtonWebLink | Link | undefined>(undefined);
+  const rendererRef = useRef<Renderer | undefined>(undefined);
+  const [session, setSession] = useState<LinkSession | undefined>();
+  const [mode, setMode] = useState<Mode | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState("Not connected");
+  const [burned, setBurned] = useState(false);
+
+  const openWith = async (next: Mode) => {
+    setMode(next);
+    await nextFrame();
+  };
+
+  const closeModal = () => setMode(null);
+
+  const connect = async () => {
+    setBusy(true);
+    await openWith("connect");
+    if (!targetRef.current) {
+      setBusy(false);
+      return;
+    }
+    try {
+      const result = await ProtonWebSDK({
+        linkOptions: {
+          endpoints: ENDPOINTS,
+          chainId: CHAIN_ID,
+          restoreSession: false,
+        },
+        transportOptions: {
+          requestAccount: REQUEST_ACCOUNT,
+          requestStatus: false,
+        },
+        uiOptions: {
+          appInfo: {name: "renderTarget demo"},
+          renderTarget: targetRef.current,
+        },
+      });
+      linkRef.current = result.link;
+      rendererRef.current = result.renderer;
+      if (result.session) {
+        setSession(result.session);
+        setStatus(`Connected as ${result.session.auth.actor}`);
+        setMode("done");
+      } else {
+        setStatus("Login cancelled");
+        closeModal();
+      }
+    } catch (err) {
+      setStatus(`Error: ${(err as Error).message}`);
+      closeModal();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const transfer = async (
+    to: string,
+    memo: string,
+    successLabel: string,
+    embedded: boolean,
+  ) => {
+    if (!session) return;
+    setBusy(true);
+    if (embedded) {
+      await openWith("sign");
+      rendererRef.current?.setRenderTarget(targetRef.current!);
+    } else {
+      rendererRef.current?.setRenderTarget(null);
+    }
+    try {
+      await session.transact(
+        {
+          actions: [
+            {
+              account: "eosio.token",
+              name: "transfer",
+              data: {
+                from: session.auth.actor,
+                to,
+                quantity: "0.0001 XPR",
+                memo,
+              },
+              authorization: [session.auth],
+            },
+          ],
+        },
+        {broadcast: true},
+      );
+      setStatus(successLabel);
+      if (embedded) setMode("done");
+    } catch (err) {
+      setStatus(`Error: ${(err as Error).message}`);
+      if (embedded) setMode("done");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const sendToTaskly = () =>
+    transfer(
+      REQUEST_ACCOUNT,
+      "renderTarget example",
+      "Transfer signed and broadcast",
+      false,
+    );
+
+  const burn = async () => {
+    await transfer(
+      BURN_ACCOUNT,
+      "burn",
+      "Burned 0.0001 XPR to eosio.null",
+      true,
+    );
+    setBurned(true);
+  };
+
+  const logout = async () => {
+    if (linkRef.current && session) {
+      await linkRef.current.removeSession(
+        REQUEST_ACCOUNT,
+        session.auth,
+        CHAIN_ID,
+      );
+    }
+    linkRef.current = undefined;
+    rendererRef.current = undefined;
+    setSession(undefined);
+    setStatus("Not connected");
+    setBurned(false);
+  };
+
+  return (
+    <>
+      <div className="page">
+        <h1>Proton Web SDK — renderTarget example</h1>
+        <p>
+          Clicking <strong>Connect</strong> opens a two-pane modal: the left
+          side is your own UI, and the SDK dialog mounts into the right pane
+          using the new <code>renderTarget</code> option.
+        </p>
+
+        <div className="status">{status}</div>
+
+        {!session ? (
+          <button onClick={connect} disabled={busy}>
+            {busy ? "Opening…" : "Connect wallet"}
+          </button>
+        ) : (
+          <div className="actions">
+            <button onClick={sendToTaskly} disabled={busy}>
+              {busy ? "Signing…" : "Send 0.0001 XPR"}
+            </button>
+            <button onClick={logout} disabled={busy} className="secondary">
+              Logout
+            </button>
+          </div>
+        )}
+      </div>
+
+      {mode && (
+        <div
+          className="backdrop"
+          onMouseDown={e => {
+            if (e.target === e.currentTarget && !busy) closeModal();
+          }}
+        >
+          <div className="modal">
+            <aside className="message">
+              <div className="message-body">
+                <h2>Challenge render target!</h2>
+                <p>
+                  Let's make this fun! Added a render target to allow Web SDK
+                  dialog to show in any part of your own ui.
+                </p>
+                <ul className="tasks">
+                  <li
+                    className={`task ${
+                      session ? "done" : mode === "connect" ? "active" : ""
+                    }`}
+                  >
+                    <span className="task-bullet">{session ? "✓" : "1"}</span>
+                    <div className="task-body">
+                      <div className="task-label">Connect your wallet</div>
+                      {session && (
+                        <div className="task-sub">
+                          Connected as @{String(session.auth.actor)}
+                        </div>
+                      )}
+                    </div>
+                  </li>
+                  <li
+                    className={`task ${
+                      burned
+                        ? "done"
+                        : session && mode === "sign"
+                          ? "active"
+                          : ""
+                    }`}
+                  >
+                    <span className="task-bullet">{burned ? "✓" : "2"}</span>
+                    <div className="task-body">
+                      <div className="task-label">Burn 0.0001 XPR</div>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+              {mode === "done" && <button onClick={closeModal}>Close</button>}
+            </aside>
+            <div ref={targetRef} className="render-target">
+              {mode === "done" && session && (
+                <div className="success">
+                  <div className="success-ring">
+                    <svg viewBox="0 0 48 48" width="44" height="44">
+                      <polyline
+                        points="14,25 21,32 34,18"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  </div>
+                  <h3>
+                    {status.startsWith("Transfer")
+                      ? "Transaction signed"
+                      : "Wallet connected"}
+                  </h3>
+                  <p className="account">{String(session.auth.actor)}</p>
+                  <p className="success-hint">
+                    {status.startsWith("Transfer") ||
+                    status.startsWith("Burned")
+                      ? "Your transaction has been broadcast to the network."
+                      : "You can now sign transactions from this app."}
+                  </p>
+                  <button className="burn" onClick={burn} disabled={busy}>
+                    {busy ? "Signing…" : "Burn 0.0001 XPR"}
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};

--- a/examples/react-render-target/src/main.tsx
+++ b/examples/react-render-target/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { App } from './App'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/examples/react-render-target/tsconfig.app.json
+++ b/examples/react-render-target/tsconfig.app.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/examples/react-render-target/tsconfig.json
+++ b/examples/react-render-target/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/examples/react-render-target/tsconfig.node.json
+++ b/examples/react-render-target/tsconfig.node.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/react-render-target/vite.config.ts
+++ b/examples/react-render-target/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})

--- a/packages/proton-web-renderer/src/index.ts
+++ b/packages/proton-web-renderer/src/index.ts
@@ -62,9 +62,17 @@ export class WebRenderer implements UIRenderer {
 
   async selectWallet({
     enabledWallets: wallets,
-  }: {enabledWallets?: UIWalletType[] | string[]} = {}): Promise<string> {
+    renderTarget,
+  }: {
+    enabledWallets?: UIWalletType[] | string[]
+    renderTarget?: HTMLElement | string
+  } = {}): Promise<string> {
     if (!wallets) {
       wallets = ENABLED_WALLETS
+    }
+
+    if (renderTarget) {
+      this.setRenderTarget(renderTarget)
     }
 
     enabledWallets.set(new Set(wallets as UIWalletType[]))
@@ -89,6 +97,9 @@ export class WebRenderer implements UIRenderer {
     if (payload.wallet_type === SUPPORTED_WALLETS.ANCHOR) {
       route = ROUTES.OTHER_ANCHOR_USE
     }
+    if (payload.renderTarget) {
+      this.setRenderTarget(payload.renderTarget)
+    }
     this.request(route, payload)
   }
 
@@ -96,6 +107,9 @@ export class WebRenderer implements UIRenderer {
     let route = ROUTES.WEBAUTH_SIGN
     if (payload.wallet_type === SUPPORTED_WALLETS.ANCHOR) {
       route = ROUTES.OTHER_ANCHOR_SIGN
+    }
+    if (payload.renderTarget) {
+      this.setRenderTarget(payload.renderTarget)
     }
     this.sign_request(route, payload)
   }
@@ -105,10 +119,16 @@ export class WebRenderer implements UIRenderer {
     if (payload.wallet_type === SUPPORTED_WALLETS.ANCHOR) {
       route = ROUTES.OTHER_ANCHOR_SIGN_MANUAL
     }
+    if (payload.renderTarget) {
+      this.setRenderTarget(payload.renderTarget)
+    }
     this.request(route, payload)
   }
 
   showError(payload: UIErrorPayload): void {
+    if (payload.renderTarget) {
+      this.setRenderTarget(payload.renderTarget)
+    }
     error.set(payload.data)
     this.show()
   }
@@ -117,6 +137,10 @@ export class WebRenderer implements UIRenderer {
     let route = ROUTES.WEBAUTH_SIGN
     if (payload.wallet_type === SUPPORTED_WALLETS.ANCHOR) {
       route = ROUTES.OTHER_ANCHOR_SIGN
+    }
+
+    if (payload.renderTarget) {
+      this.setRenderTarget(payload.renderTarget)
     }
 
     recoverError.set(payload.data)
@@ -266,13 +290,38 @@ export class WebRenderer implements UIRenderer {
     this.initialized = true
   }
 
+  private resolveRenderTarget(target: HTMLElement | string | undefined): HTMLElement {
+    if (target instanceof HTMLElement) {
+      return target
+    }
+    if (typeof target === 'string') {
+      const found = document.querySelector<HTMLElement>(target)
+      if (found) {
+        return found
+      }
+    }
+    return document.body
+  }
+
+  setRenderTarget(target: HTMLElement | string): void {
+    this.options.renderTarget = target
+    if (!this.initialized || !this.element) {
+      return
+    }
+    const parent = this.resolveRenderTarget(target)
+    if (this.element.parentNode !== parent) {
+      parent.append(this.element)
+    }
+  }
+
   private appendDialogElement() {
     const existing = document.getElementById(this.elementId)
     if (!this.element || !this.shadow) {
       throw new Error('The WebRenderer is not initialized. Call the initialize method first.')
     }
     if (!existing) {
-      document.body.append(this.element)
+      const target = this.resolveRenderTarget(this.options.renderTarget)
+      target.append(this.element)
       this.offDOMContentLoaded()
 
       this.app = mount(App, {

--- a/packages/proton-web-renderer/src/index.ts
+++ b/packages/proton-web-renderer/src/index.ts
@@ -15,6 +15,7 @@ import {
   backAction,
   closeAction,
   demoMode,
+  embeddedMode,
   enabledWallets,
   error,
   manualAction,
@@ -65,7 +66,7 @@ export class WebRenderer implements UIRenderer {
     renderTarget,
   }: {
     enabledWallets?: UIWalletType[] | string[]
-    renderTarget?: HTMLElement | string
+    renderTarget?: HTMLElement | string | null
   } = {}): Promise<string> {
     if (!wallets) {
       wallets = ENABLED_WALLETS
@@ -290,7 +291,9 @@ export class WebRenderer implements UIRenderer {
     this.initialized = true
   }
 
-  private resolveRenderTarget(target: HTMLElement | string | undefined): HTMLElement {
+  private resolveRenderTarget(
+    target: HTMLElement | string | null | undefined
+  ): HTMLElement {
     if (target instanceof HTMLElement) {
       return target
     }
@@ -303,7 +306,7 @@ export class WebRenderer implements UIRenderer {
     return document.body
   }
 
-  setRenderTarget(target: HTMLElement | string): void {
+  setRenderTarget(target: HTMLElement | string | null): void {
     this.options.renderTarget = target
     if (!this.initialized || !this.element) {
       return
@@ -312,6 +315,7 @@ export class WebRenderer implements UIRenderer {
     if (this.element.parentNode !== parent) {
       parent.append(this.element)
     }
+    embeddedMode.set(parent !== document.body)
   }
 
   private appendDialogElement() {
@@ -322,6 +326,7 @@ export class WebRenderer implements UIRenderer {
     if (!existing) {
       const target = this.resolveRenderTarget(this.options.renderTarget)
       target.append(this.element)
+      embeddedMode.set(target !== document.body)
       this.offDOMContentLoaded()
 
       this.app = mount(App, {

--- a/packages/proton-web-renderer/src/types.ts
+++ b/packages/proton-web-renderer/src/types.ts
@@ -13,12 +13,14 @@ export type UISpace =
 
 export interface UIRendererOptions extends UIProps {
   id?: string
+  renderTarget?: HTMLElement | string
 }
 
 interface UIGenericPayload {
   wallet_type: UIWalletType | string
   onClose?: () => void
   onBack?: () => void
+  renderTarget?: HTMLElement | string
 }
 
 export interface UIRequestPayload extends UIGenericPayload {
@@ -31,6 +33,7 @@ export type UISignManuallyPayload = UIRequestPayload
 export interface UIErrorPayload {
   wallet_type: UIWalletType | string
   data: UIError
+  renderTarget?: HTMLElement | string
 }
 
 export interface UISignPayload extends UIGenericPayload {
@@ -51,4 +54,5 @@ export interface UIRenderer {
   close(): void
   destroy(): void
   showLoading(): void
+  setRenderTarget(_: HTMLElement | string): void
 }

--- a/packages/proton-web-renderer/src/types.ts
+++ b/packages/proton-web-renderer/src/types.ts
@@ -13,14 +13,14 @@ export type UISpace =
 
 export interface UIRendererOptions extends UIProps {
   id?: string
-  renderTarget?: HTMLElement | string
+  renderTarget?: HTMLElement | string | null
 }
 
 interface UIGenericPayload {
   wallet_type: UIWalletType | string
   onClose?: () => void
   onBack?: () => void
-  renderTarget?: HTMLElement | string
+  renderTarget?: HTMLElement | string | null
 }
 
 export interface UIRequestPayload extends UIGenericPayload {
@@ -33,7 +33,7 @@ export type UISignManuallyPayload = UIRequestPayload
 export interface UIErrorPayload {
   wallet_type: UIWalletType | string
   data: UIError
-  renderTarget?: HTMLElement | string
+  renderTarget?: HTMLElement | string | null
 }
 
 export interface UISignPayload extends UIGenericPayload {
@@ -54,5 +54,5 @@ export interface UIRenderer {
   close(): void
   destroy(): void
   showLoading(): void
-  setRenderTarget(_: HTMLElement | string): void
+  setRenderTarget(_: HTMLElement | string | null): void
 }

--- a/packages/proton-web-renderer/src/ui/components/Countdown.svelte
+++ b/packages/proton-web-renderer/src/ui/components/Countdown.svelte
@@ -114,6 +114,7 @@
   }
 
   .content {
+    position: relative;
     background: black;
     border-radius: inherit;
     box-sizing: border-box;
@@ -124,7 +125,7 @@
     align-items: center;
     border: 1px solid rgba(var(--countdown-background), 0.05);
     background: rgba(var(--countdown-background), 0.05);
-    z-index: -1;
+    z-index: 0;
   }
 
   .label {

--- a/packages/proton-web-renderer/src/ui/components/Modal.svelte
+++ b/packages/proton-web-renderer/src/ui/components/Modal.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import type {Unsubscriber} from 'svelte/store'
 
-  import {active, resetState, theme} from '../store'
+  import {active, embeddedMode, resetState, theme} from '../store'
+  import {get} from 'svelte/store'
   import {onDestroy, onMount, type Snippet} from 'svelte'
   import {on} from 'svelte/events'
   import {eventSelf} from '../utils'
@@ -20,7 +21,11 @@
     unsubscribe = active.subscribe((value) => {
       if (dialog) {
         if (value && !dialog.open) {
-          dialog.showModal()
+          if (get(embeddedMode)) {
+            dialog.show()
+          } else {
+            dialog.showModal()
+          }
         } else if (!value && dialog.open) {
           dialog.close()
           resetState()
@@ -73,7 +78,7 @@
   })
 </script>
 
-<dialog bind:this={dialog} data-theme={$theme}>
+<dialog bind:this={dialog} data-theme={$theme} data-embedded={$embeddedMode ? 'true' : undefined}>
   {@render content?.()}
 </dialog>
 
@@ -99,6 +104,19 @@
 
     &::backdrop {
       background: rgba(0, 0, 0, 0.75);
+    }
+
+    &[data-embedded='true'] {
+      position: absolute;
+      inset: 0;
+      margin: 0;
+      width: 100%;
+      max-width: 100%;
+      height: 100%;
+      max-height: 100%;
+      border: none;
+      border-radius: 0;
+      --max-modal-content-height: 100%;
     }
   }
 

--- a/packages/proton-web-renderer/src/ui/store.ts
+++ b/packages/proton-web-renderer/src/ui/store.ts
@@ -19,6 +19,9 @@ const defaultUIProps: UIProps = {}
 
 export const app_props = writable<UIProps>(defaultUIProps)
 
+/** Whether the dialog is mounted into a custom renderTarget (non-modal mode) */
+export const embeddedMode = writable<boolean>(false)
+
 /** Whether or not the interface is active in the browser */
 export const active = writable<boolean>(false)
 

--- a/packages/proton-web-sdk/src/connect.ts
+++ b/packages/proton-web-sdk/src/connect.ts
@@ -53,9 +53,15 @@ export const ConnectWallet = async ({
 
   if (!renderer) {
     renderer = new WebRenderer(uiOptions)
+  } else if (uiOptions.renderTarget) {
+    renderer.setRenderTarget(uiOptions.renderTarget)
   }
 
-  return await login({selectorOptions, linkOptions, transportOptions})
+  const result = await login({selectorOptions, linkOptions, transportOptions})
+  if (result) {
+    ;(result as ConnectWalletRet).renderer = renderer
+  }
+  return result
 }
 
 const login = async (

--- a/packages/proton-web-sdk/src/types.ts
+++ b/packages/proton-web-sdk/src/types.ts
@@ -1,7 +1,7 @@
 import type {Link, LinkOptions, LinkSession, LinkStorage, LoginResult} from '@proton/link'
 import type {BrowserTransportOptions} from '@proton/browser-transport'
 import type {ProtonWebLink} from './links/protonWeb'
-import type {UIRendererOptions} from '@proton/web-renderer'
+import type {UIRendererOptions, WebRenderer} from '@proton/web-renderer'
 
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
@@ -31,6 +31,7 @@ export interface ConnectWalletRet {
   session?: LinkSession
   link?: ProtonWebLink | Link
   loginResult?: LoginResult
+  renderer?: WebRenderer
   error?: any
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,34 @@ importers:
         specifier: ~5.9.2
         version: 5.9.3
 
+  examples/react-render-target:
+    dependencies:
+      '@proton/web-sdk':
+        specifier: workspace:^
+        version: link:../../packages/proton-web-sdk
+      react:
+        specifier: ^19.1.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.1.2
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.1.2
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.4.1
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      vite:
+        specifier: ^6.3.5
+        version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)
+
   examples/svelte:
     dependencies:
       '@proton/js':


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/bbdff19f-a7dc-4f50-bde7-33bf18b904a4

Lets consumers mount the SDK dialog into any DOM element instead of `document.body`, and visually confine it to that element — not just reparent it.

- **`UIRendererOptions.renderTarget`** accepts an `HTMLElement`, a CSS selector string, or `null` (explicit reset to `document.body`).
- **`WebRenderer.setRenderTarget(target)`** re-parents the host element on the fly; the ConnectWallet flow returns the renderer so consumers can switch targets per `session.transact(...)`.
- **Per-call overrides** on `selectWallet` / `login` / `sign` / `signManually` / `showError` / `recoverError` payloads (`renderTarget?` field).
- **Embedded mode**: when a custom render target is active, `Modal.svelte` calls `dialog.show()` instead of `dialog.showModal()`, so the browser does not promote the dialog to the top layer. A new `embeddedMode` store + `data-embedded` attribute switches CSS so the dialog fills its container at 100% width/height (no border radius, no backdrop).
- New example `examples/react-render-target` demonstrating the flow: a two-pane "Challenge render target!" modal that drives `connect` + `burn 0.0001 XPR` through an embedded SDK dialog, plus a regular page-level transfer that resets the target to `null` and uses the default full-viewport dialog.

## Test plan

- [ ] `pnpm install` at the repo root.
- [ ] `pnpm --filter example-react-render-target dev` boots Vite without type or build errors.
- [ ] Click **Connect wallet** — the two-pane modal opens and the SDK panel renders inside the 340px right column (not over the viewport).
- [ ] Inside the modal, click **Burn 0.0001 XPR** — SDK signing panel re-appears inline in the same right column; on broadcast, checkbox 2 ticks.
- [ ] Complete login — left pane checkbox 1 ticks with `Connected as @<actor>`.
- [ ] Close the modal, then click **Send 0.0001 XPR** on the page — the SDK opens as the regular full-viewport modal (validates `setRenderTarget(null)` reset).
- [ ] Click **Logout** — session clears, checklist state resets.
- [ ] Existing examples (`examples/react`, `vue`, `svelte`, `angular`, `vanilla-html`, `react-native`) still behave as before (default `document.body` modal).